### PR TITLE
Deprecate bunk locality point in IE

### DIFF
--- a/data/129/342/416/9/1293424169.geojson
+++ b/data/129/342/416/9/1293424169.geojson
@@ -3,6 +3,7 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2019-07-24",
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
@@ -25,7 +26,7 @@
     "gn:timezone":"Europe/Dublin",
     "iso:country":"IE",
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191581,
@@ -47,7 +48,7 @@
         }
     ],
     "wof:id":1293424169,
-    "wof:lastmodified":1536877537,
+    "wof:lastmodified":1563992243,
     "wof:name":"Cloghbrack",
     "wof:parent_id":85685145,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1677.

Deprecated a bunk locality point in Ireland. No PIP work required, can merge once approved.