### PR TITLE
Updated locality name

### DIFF
--- a/data/122/627/648/3/1226276483.geojson
+++ b/data/122/627/648/3/1226276483.geojson
@@ -30,6 +30,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Drumganagh"
+    ],
+    "name:eng_x_variant":[
+        "Drunganagh"
+    ],
     "src:geom":"geonames",
     "wof:belongsto":[
         102191581,
@@ -51,8 +57,8 @@
         }
     ],
     "wof:id":1226276483,
-    "wof:lastmodified":1566680468,
-    "wof:name":"Drunganagh",
+    "wof:lastmodified":1573514123,
+    "wof:name":"Drumganagh",
     "wof:parent_id":85685145,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ie",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1700

- Updates "Drumganagh" locality, changing the name from "Drunganagh" to "Drumganagh" and storing the existing name as a variant.
- No PIP work or geometry changes, can merge once approved.