### PR TITLE
geom_alt props

### DIFF
--- a/data/101/751/727/101751727.geojson
+++ b/data/101/751/727/101751727.geojson
@@ -477,6 +477,9 @@
         "qs_pg:id":478991
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"051661ea844e4e39e165c02bbfbc20b1",
     "wof:hierarchy":[
         {
@@ -487,7 +490,7 @@
         }
     ],
     "wof:id":101751727,
-    "wof:lastmodified":1566680124,
+    "wof:lastmodified":1582356308,
     "wof:name":"Cork",
     "wof:parent_id":85684945,
     "wof:placetype":"locality",

--- a/data/101/751/733/101751733.geojson
+++ b/data/101/751/733/101751733.geojson
@@ -407,6 +407,9 @@
         "qs_pg:id":897868
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"130b27d8e84e3b286a83884c99f0a28b",
     "wof:hierarchy":[
         {
@@ -417,7 +420,7 @@
         }
     ],
     "wof:id":101751733,
-    "wof:lastmodified":1566680124,
+    "wof:lastmodified":1582356308,
     "wof:name":"Limerick",
     "wof:parent_id":85684987,
     "wof:placetype":"locality",

--- a/data/101/751/737/101751737.geojson
+++ b/data/101/751/737/101751737.geojson
@@ -714,6 +714,9 @@
         85685015
     ],
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"eb7686ac400c7f7db6d337fb047ecd60",
     "wof:hierarchy":[
         {
@@ -727,7 +730,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566680124,
+    "wof:lastmodified":1582356308,
     "wof:megacity":1,
     "wof:name":"Dublin",
     "wof:parent_id":85685015,

--- a/data/101/753/081/101753081.geojson
+++ b/data/101/753/081/101753081.geojson
@@ -186,6 +186,9 @@
         "wk:page":"Bray"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6ccd91a0470a31e53f9bd56a482bf661",
     "wof:hierarchy":[
         {
@@ -196,7 +199,7 @@
         }
     ],
     "wof:id":101753081,
-    "wof:lastmodified":1566680092,
+    "wof:lastmodified":1582356303,
     "wof:name":"Bray",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/101/753/083/101753083.geojson
+++ b/data/101/753/083/101753083.geojson
@@ -113,6 +113,9 @@
         "wk:page":"Rathcoole, County Dublin"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7b7e3a7a9d34f4709f48f4e03a988df6",
     "wof:hierarchy":[
         {
@@ -123,7 +126,7 @@
         }
     ],
     "wof:id":101753083,
-    "wof:lastmodified":1566680091,
+    "wof:lastmodified":1582356302,
     "wof:name":"Rathcoole",
     "wof:parent_id":85685009,
     "wof:placetype":"locality",

--- a/data/101/753/085/101753085.geojson
+++ b/data/101/753/085/101753085.geojson
@@ -137,6 +137,9 @@
         "wk:page":"Leixlip"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"04c8634fb5ec8deadb65bb9fde1dd5cb",
     "wof:hierarchy":[
         {
@@ -147,7 +150,7 @@
         }
     ],
     "wof:id":101753085,
-    "wof:lastmodified":1566680091,
+    "wof:lastmodified":1582356303,
     "wof:name":"Leixlip",
     "wof:parent_id":85685025,
     "wof:placetype":"locality",

--- a/data/101/753/087/101753087.geojson
+++ b/data/101/753/087/101753087.geojson
@@ -160,6 +160,9 @@
         "wk:page":"Swords, Dublin"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"de93676bc3ca8a07750c895a8a0c954b",
     "wof:hierarchy":[
         {
@@ -170,7 +173,7 @@
         }
     ],
     "wof:id":101753087,
-    "wof:lastmodified":1566680092,
+    "wof:lastmodified":1582356303,
     "wof:name":"Swords",
     "wof:parent_id":85685045,
     "wof:placetype":"locality",

--- a/data/101/753/093/101753093.geojson
+++ b/data/101/753/093/101753093.geojson
@@ -104,6 +104,9 @@
         "wk:page":"Portmarnock"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ba5c710142f47a7d94a01abc5bc696c3",
     "wof:hierarchy":[
         {
@@ -114,7 +117,7 @@
         }
     ],
     "wof:id":101753093,
-    "wof:lastmodified":1566680092,
+    "wof:lastmodified":1582356303,
     "wof:name":"Portmarnock",
     "wof:parent_id":85685045,
     "wof:placetype":"locality",

--- a/data/101/803/605/101803605.geojson
+++ b/data/101/803/605/101803605.geojson
@@ -119,6 +119,9 @@
         "wk:page":"Macroom"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7b34463efda2f13d58899f4879834296",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
         }
     ],
     "wof:id":101803605,
-    "wof:lastmodified":1566680108,
+    "wof:lastmodified":1582356306,
     "wof:name":"Macroom",
     "wof:parent_id":85684963,
     "wof:placetype":"locality",

--- a/data/101/803/607/101803607.geojson
+++ b/data/101/803/607/101803607.geojson
@@ -137,6 +137,9 @@
         "wk:page":"Enniscorthy"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f950baeb2368850a2c820b3e666ffc2c",
     "wof:hierarchy":[
         {
@@ -147,7 +150,7 @@
         }
     ],
     "wof:id":101803607,
-    "wof:lastmodified":1566680108,
+    "wof:lastmodified":1582356306,
     "wof:name":"Enniscorthy",
     "wof:parent_id":85684967,
     "wof:placetype":"locality",

--- a/data/101/803/613/101803613.geojson
+++ b/data/101/803/613/101803613.geojson
@@ -264,6 +264,9 @@
         "wk:page":"Killarney"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d1d06400b4e45fefd14c90eba9d855e4",
     "wof:hierarchy":[
         {
@@ -274,7 +277,7 @@
         }
     ],
     "wof:id":101803613,
-    "wof:lastmodified":1566680108,
+    "wof:lastmodified":1582356306,
     "wof:name":"Killarney",
     "wof:parent_id":85684991,
     "wof:placetype":"locality",

--- a/data/101/804/741/101804741.geojson
+++ b/data/101/804/741/101804741.geojson
@@ -91,6 +91,9 @@
         "wk:page":"Dunlavin"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e47a7434fdd1cb5be86f8bc900de9457",
     "wof:hierarchy":[
         {
@@ -104,7 +107,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566680101,
+    "wof:lastmodified":1582356305,
     "wof:name":"Dunlavin",
     "wof:parent_id":85684999,
     "wof:placetype":"locality",

--- a/data/101/804/745/101804745.geojson
+++ b/data/101/804/745/101804745.geojson
@@ -107,6 +107,9 @@
         "wk:page":"Portarlington, County Laois"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9f6c3163d4098c85e48a5a30293d72c1",
     "wof:hierarchy":[
         {
@@ -117,7 +120,7 @@
         }
     ],
     "wof:id":101804745,
-    "wof:lastmodified":1566680107,
+    "wof:lastmodified":1582356306,
     "wof:name":"Portarlington",
     "wof:parent_id":85685005,
     "wof:placetype":"locality",

--- a/data/101/804/747/101804747.geojson
+++ b/data/101/804/747/101804747.geojson
@@ -107,6 +107,9 @@
         "wk:page":"Mountmellick"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"77246b496a0f3bd54353ba56e60802ec",
     "wof:hierarchy":[
         {
@@ -117,7 +120,7 @@
         }
     ],
     "wof:id":101804747,
-    "wof:lastmodified":1566680100,
+    "wof:lastmodified":1582356305,
     "wof:name":"Mountmellick",
     "wof:parent_id":85685005,
     "wof:placetype":"locality",

--- a/data/101/804/749/101804749.geojson
+++ b/data/101/804/749/101804749.geojson
@@ -179,6 +179,9 @@
         "wk:page":"Port Laoise"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"052e60aeff960e8815b68e2b91d68c5b",
     "wof:hierarchy":[
         {
@@ -189,7 +192,7 @@
         }
     ],
     "wof:id":101804749,
-    "wof:lastmodified":1566680100,
+    "wof:lastmodified":1582356305,
     "wof:name":"Portlaoise",
     "wof:parent_id":85685005,
     "wof:placetype":"locality",

--- a/data/101/804/755/101804755.geojson
+++ b/data/101/804/755/101804755.geojson
@@ -90,6 +90,9 @@
         "wk:page":"Stradbally"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"cd7a992888a149ecd231adcf9e185eb1",
     "wof:hierarchy":[
         {
@@ -103,7 +106,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566680095,
+    "wof:lastmodified":1582356304,
     "wof:name":"Stradbally",
     "wof:parent_id":85685005,
     "wof:placetype":"locality",

--- a/data/101/804/759/101804759.geojson
+++ b/data/101/804/759/101804759.geojson
@@ -89,6 +89,9 @@
         "wk:page":"Durrow, County Laois"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2709b43cfc2ffef5342b9665183c281a",
     "wof:hierarchy":[
         {
@@ -102,7 +105,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566680103,
+    "wof:lastmodified":1582356305,
     "wof:name":"Durrow",
     "wof:parent_id":85685005,
     "wof:placetype":"locality",

--- a/data/101/804/765/101804765.geojson
+++ b/data/101/804/765/101804765.geojson
@@ -83,6 +83,9 @@
         "wk:page":"Borrisokane"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3a3ca196aa4b0a2c36b05c5e8c6df90e",
     "wof:hierarchy":[
         {
@@ -93,7 +96,7 @@
         }
     ],
     "wof:id":101804765,
-    "wof:lastmodified":1566680096,
+    "wof:lastmodified":1582356304,
     "wof:name":"Borrisokane",
     "wof:parent_id":1159294375,
     "wof:placetype":"locality",

--- a/data/101/804/767/101804767.geojson
+++ b/data/101/804/767/101804767.geojson
@@ -129,6 +129,9 @@
         "wk:page":"Roscrea"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a264726c6e0bcc91c4e6cb119fab2f89",
     "wof:hierarchy":[
         {
@@ -139,7 +142,7 @@
         }
     ],
     "wof:id":101804767,
-    "wof:lastmodified":1566680102,
+    "wof:lastmodified":1582356305,
     "wof:name":"Roscrea",
     "wof:parent_id":1159294375,
     "wof:placetype":"locality",

--- a/data/101/804/771/101804771.geojson
+++ b/data/101/804/771/101804771.geojson
@@ -161,6 +161,9 @@
         "wk:page":"Nenagh"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d96ebc9af87b2da24f9953d06b5fe768",
     "wof:hierarchy":[
         {
@@ -171,7 +174,7 @@
         }
     ],
     "wof:id":101804771,
-    "wof:lastmodified":1566680100,
+    "wof:lastmodified":1582356305,
     "wof:name":"Nenagh",
     "wof:parent_id":1159294375,
     "wof:placetype":"locality",

--- a/data/101/804/773/101804773.geojson
+++ b/data/101/804/773/101804773.geojson
@@ -104,6 +104,9 @@
         "wk:page":"Templemore"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"56893f3d05154c42259f09bd047b037b",
     "wof:hierarchy":[
         {
@@ -114,7 +117,7 @@
         }
     ],
     "wof:id":101804773,
-    "wof:lastmodified":1566680107,
+    "wof:lastmodified":1582356306,
     "wof:name":"Templemore",
     "wof:parent_id":1159294375,
     "wof:placetype":"locality",

--- a/data/101/804/775/101804775.geojson
+++ b/data/101/804/775/101804775.geojson
@@ -80,6 +80,9 @@
         "wk:page":"Borrisoleigh"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d3dd4936b703453a4d2a614ee774ca65",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
         }
     ],
     "wof:id":101804775,
-    "wof:lastmodified":1566680106,
+    "wof:lastmodified":1582356306,
     "wof:name":"Borrisoleigh",
     "wof:parent_id":1159294375,
     "wof:placetype":"locality",

--- a/data/101/804/779/101804779.geojson
+++ b/data/101/804/779/101804779.geojson
@@ -111,6 +111,9 @@
         "wk:page":"Monasterevin"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"66c241fced0db4099a69ee77f542cf1f",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566680101,
+    "wof:lastmodified":1582356305,
     "wof:name":"Monasterevin",
     "wof:parent_id":85685025,
     "wof:placetype":"locality",

--- a/data/101/804/781/101804781.geojson
+++ b/data/101/804/781/101804781.geojson
@@ -152,6 +152,9 @@
         "wk:page":"Kildare"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7e3213501de96352cfa90c8e4735cb3d",
     "wof:hierarchy":[
         {
@@ -165,7 +168,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566680106,
+    "wof:lastmodified":1582356306,
     "wof:name":"Kildare",
     "wof:parent_id":85685025,
     "wof:placetype":"locality",

--- a/data/101/804/783/101804783.geojson
+++ b/data/101/804/783/101804783.geojson
@@ -153,6 +153,9 @@
         "wk:page":"Newbridge, County Kildare"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d9dd15309493b5b0d4c5c3fc07ec0ad4",
     "wof:hierarchy":[
         {
@@ -163,7 +166,7 @@
         }
     ],
     "wof:id":101804783,
-    "wof:lastmodified":1566680101,
+    "wof:lastmodified":1582356305,
     "wof:name":"Newbridge",
     "wof:parent_id":85685025,
     "wof:placetype":"locality",

--- a/data/101/804/785/101804785.geojson
+++ b/data/101/804/785/101804785.geojson
@@ -87,6 +87,9 @@
         "wk:page":"Robertstown"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5a3d6ae6db7cb4fd695316be16a42f88",
     "wof:hierarchy":[
         {
@@ -100,7 +103,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566680100,
+    "wof:lastmodified":1582356305,
     "wof:name":"Robertstown",
     "wof:parent_id":85685025,
     "wof:placetype":"locality",

--- a/data/101/804/793/101804793.geojson
+++ b/data/101/804/793/101804793.geojson
@@ -147,6 +147,9 @@
         "wk:page":"Maynooth"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"db4f0c2cdc64ddc559dc338d9dc59dd7",
     "wof:hierarchy":[
         {
@@ -160,7 +163,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566680102,
+    "wof:lastmodified":1582356305,
     "wof:name":"Maynooth",
     "wof:parent_id":85685025,
     "wof:placetype":"locality",

--- a/data/101/804/797/101804797.geojson
+++ b/data/101/804/797/101804797.geojson
@@ -137,6 +137,9 @@
         "qs_pg:id":1040433
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c1a34be08b8d023f300ee4ec24ce42fb",
     "wof:hierarchy":[
         {
@@ -147,7 +150,7 @@
         }
     ],
     "wof:id":101804797,
-    "wof:lastmodified":1566680094,
+    "wof:lastmodified":1582356304,
     "wof:name":"Athy",
     "wof:parent_id":85685025,
     "wof:placetype":"locality",

--- a/data/101/804/799/101804799.geojson
+++ b/data/101/804/799/101804799.geojson
@@ -115,6 +115,9 @@
         "wk:page":"Castledermot"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"eecae7e1a4a2094d5f0ba534ff3157d6",
     "wof:hierarchy":[
         {
@@ -128,7 +131,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566680095,
+    "wof:lastmodified":1582356304,
     "wof:name":"Castledermot",
     "wof:parent_id":85685025,
     "wof:placetype":"locality",

--- a/data/101/804/809/101804809.geojson
+++ b/data/101/804/809/101804809.geojson
@@ -183,6 +183,9 @@
         "qs_pg:id":1078403
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"83eeea2661a714b392b58576db48b13b",
     "wof:hierarchy":[
         {
@@ -193,7 +196,7 @@
         }
     ],
     "wof:id":101804809,
-    "wof:lastmodified":1566680104,
+    "wof:lastmodified":1582356305,
     "wof:name":"Ennis",
     "wof:parent_id":85685037,
     "wof:placetype":"locality",

--- a/data/101/804/811/101804811.geojson
+++ b/data/101/804/811/101804811.geojson
@@ -102,6 +102,9 @@
         "wk:page":"Scarriff"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"caa1c40592eac304f2b52288a0a9bc19",
     "wof:hierarchy":[
         {
@@ -115,7 +118,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566680097,
+    "wof:lastmodified":1582356304,
     "wof:name":"Scarriff",
     "wof:parent_id":85685037,
     "wof:placetype":"locality",

--- a/data/101/804/813/101804813.geojson
+++ b/data/101/804/813/101804813.geojson
@@ -99,6 +99,9 @@
         "wk:page":"Cratloe"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"aeede51e02f80718207163db5147511c",
     "wof:hierarchy":[
         {
@@ -112,7 +115,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566680104,
+    "wof:lastmodified":1582356305,
     "wof:name":"Cratloe",
     "wof:parent_id":85685037,
     "wof:placetype":"locality",

--- a/data/101/804/817/101804817.geojson
+++ b/data/101/804/817/101804817.geojson
@@ -104,6 +104,9 @@
         "wk:page":"Kilrush"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"970ab4993d64b3099078bb48a64a9cd5",
     "wof:hierarchy":[
         {
@@ -114,7 +117,7 @@
         }
     ],
     "wof:id":101804817,
-    "wof:lastmodified":1566680097,
+    "wof:lastmodified":1582356304,
     "wof:name":"Kilrush",
     "wof:parent_id":85685037,
     "wof:placetype":"locality",

--- a/data/101/804/821/101804821.geojson
+++ b/data/101/804/821/101804821.geojson
@@ -252,6 +252,9 @@
         "wk:page":"Shannon, County Clare"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5d669bad07af98fd3da2a6550cfbec55",
     "wof:hierarchy":[
         {
@@ -262,7 +265,7 @@
         }
     ],
     "wof:id":101804821,
-    "wof:lastmodified":1566680098,
+    "wof:lastmodified":1582356304,
     "wof:name":"Shannon",
     "wof:parent_id":85685037,
     "wof:placetype":"locality",

--- a/data/101/804/825/101804825.geojson
+++ b/data/101/804/825/101804825.geojson
@@ -279,6 +279,9 @@
         "wk:page":"Edenderry"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"fa4918d78cf3e9fca4f089f7095e1a9f",
     "wof:hierarchy":[
         {
@@ -292,7 +295,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566680104,
+    "wof:lastmodified":1582356305,
     "wof:name":"Edenderry",
     "wof:parent_id":85685041,
     "wof:placetype":"locality",

--- a/data/101/804/829/101804829.geojson
+++ b/data/101/804/829/101804829.geojson
@@ -167,6 +167,9 @@
         "wk:page":"Tullamore"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"cfd68f5ea68eb0d88787c37fec86ea88",
     "wof:hierarchy":[
         {
@@ -177,7 +180,7 @@
         }
     ],
     "wof:id":101804829,
-    "wof:lastmodified":1566680097,
+    "wof:lastmodified":1582356304,
     "wof:name":"Tullamore",
     "wof:parent_id":85685041,
     "wof:placetype":"locality",

--- a/data/101/804/839/101804839.geojson
+++ b/data/101/804/839/101804839.geojson
@@ -84,6 +84,9 @@
         "wk:page":"Kilcormac"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"72bb57cdaad1c00c1c4015db3034ca2c",
     "wof:hierarchy":[
         {
@@ -97,7 +100,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566680105,
+    "wof:lastmodified":1582356306,
     "wof:name":"Kilcormac",
     "wof:parent_id":85685041,
     "wof:placetype":"locality",

--- a/data/101/804/843/101804843.geojson
+++ b/data/101/804/843/101804843.geojson
@@ -146,6 +146,9 @@
         "wk:page":"Francazal"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"cf66b599b637b365d0294360fc5aa8a5",
     "wof:hierarchy":[
         {
@@ -156,7 +159,7 @@
         }
     ],
     "wof:id":101804843,
-    "wof:lastmodified":1566680098,
+    "wof:lastmodified":1582356304,
     "wof:name":"Birr",
     "wof:parent_id":85685041,
     "wof:placetype":"locality",

--- a/data/101/804/845/101804845.geojson
+++ b/data/101/804/845/101804845.geojson
@@ -128,6 +128,9 @@
         "wk:page":"Balbriggan"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"58e6c395b3addb96db3e96192ef5b342",
     "wof:hierarchy":[
         {
@@ -138,7 +141,7 @@
         }
     ],
     "wof:id":101804845,
-    "wof:lastmodified":1566680097,
+    "wof:lastmodified":1582356304,
     "wof:name":"Balbriggan",
     "wof:parent_id":85685045,
     "wof:placetype":"locality",

--- a/data/101/804/847/101804847.geojson
+++ b/data/101/804/847/101804847.geojson
@@ -116,6 +116,9 @@
         "wk:page":"Skerries, Dublin"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0e7e482e6635a814f54309f6bba046d5",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
         }
     ],
     "wof:id":101804847,
-    "wof:lastmodified":1566680104,
+    "wof:lastmodified":1582356305,
     "wof:name":"Skerries",
     "wof:parent_id":85685045,
     "wof:placetype":"locality",

--- a/data/101/804/851/101804851.geojson
+++ b/data/101/804/851/101804851.geojson
@@ -103,6 +103,9 @@
         "wk:page":"Lusk, Dublin"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"76ec1f8472e5499161c2078ecd22371b",
     "wof:hierarchy":[
         {
@@ -113,7 +116,7 @@
         }
     ],
     "wof:id":101804851,
-    "wof:lastmodified":1566680099,
+    "wof:lastmodified":1582356304,
     "wof:name":"Lusk",
     "wof:parent_id":85685045,
     "wof:placetype":"locality",

--- a/data/101/804/857/101804857.geojson
+++ b/data/101/804/857/101804857.geojson
@@ -177,6 +177,9 @@
         "qs_pg:id":1040434
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e3e1b74e8b3de459d7482b40d21563e5",
     "wof:hierarchy":[
         {
@@ -187,7 +190,7 @@
         }
     ],
     "wof:id":101804857,
-    "wof:lastmodified":1566680098,
+    "wof:lastmodified":1582356304,
     "wof:name":"Athlone",
     "wof:parent_id":85685075,
     "wof:placetype":"locality",

--- a/data/101/804/861/101804861.geojson
+++ b/data/101/804/861/101804861.geojson
@@ -98,6 +98,9 @@
         "wk:page":"Moate"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"97665530d2309177b3652f5d04b50c7b",
     "wof:hierarchy":[
         {
@@ -108,7 +111,7 @@
         }
     ],
     "wof:id":101804861,
-    "wof:lastmodified":1566680098,
+    "wof:lastmodified":1582356304,
     "wof:name":"Moate",
     "wof:parent_id":85685075,
     "wof:placetype":"locality",

--- a/data/101/804/863/101804863.geojson
+++ b/data/101/804/863/101804863.geojson
@@ -108,6 +108,9 @@
         "wk:page":"Kilbeggan"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7becdbc2f2885686cfc367aa8d82847e",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566680105,
+    "wof:lastmodified":1582356306,
     "wof:name":"Kilbeggan",
     "wof:parent_id":85685075,
     "wof:placetype":"locality",

--- a/data/101/804/865/101804865.geojson
+++ b/data/101/804/865/101804865.geojson
@@ -180,6 +180,9 @@
         "qs_pg:id":1040402
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"35bc7b86fc1a7d6d00477cbc48fd7cb2",
     "wof:hierarchy":[
         {
@@ -190,7 +193,7 @@
         }
     ],
     "wof:id":101804865,
-    "wof:lastmodified":1566680104,
+    "wof:lastmodified":1582356305,
     "wof:name":"Mullingar",
     "wof:parent_id":85685075,
     "wof:placetype":"locality",

--- a/data/101/804/869/101804869.geojson
+++ b/data/101/804/869/101804869.geojson
@@ -111,6 +111,9 @@
         "wk:page":"Kinnegad"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b1ecc0fd954e47b2d69150aa472cb15c",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566680099,
+    "wof:lastmodified":1582356304,
     "wof:name":"Kinnegad",
     "wof:parent_id":85685075,
     "wof:placetype":"locality",

--- a/data/101/804/871/101804871.geojson
+++ b/data/101/804/871/101804871.geojson
@@ -108,6 +108,9 @@
         "wk:page":"Oldcastle, County Meath"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ccf4c97931fa4d7af708cc3fd84523ad",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566680104,
+    "wof:lastmodified":1582356305,
     "wof:name":"Oldcastle",
     "wof:parent_id":85685081,
     "wof:placetype":"locality",

--- a/data/101/804/873/101804873.geojson
+++ b/data/101/804/873/101804873.geojson
@@ -160,6 +160,9 @@
         "wk:page":"Kells, County Meath"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"124ed158251b98e947c2a6b378ac66c1",
     "wof:hierarchy":[
         {
@@ -170,7 +173,7 @@
         }
     ],
     "wof:id":101804873,
-    "wof:lastmodified":1566680097,
+    "wof:lastmodified":1582356304,
     "wof:name":"Kells",
     "wof:parent_id":85685081,
     "wof:placetype":"locality",

--- a/data/101/804/875/101804875.geojson
+++ b/data/101/804/875/101804875.geojson
@@ -114,6 +114,9 @@
         "wk:page":"Athboy"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"fc7e31800555032faa160afe1dc5baec",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566680098,
+    "wof:lastmodified":1582356304,
     "wof:name":"Athboy",
     "wof:parent_id":85685081,
     "wof:placetype":"locality",

--- a/data/101/804/879/101804879.geojson
+++ b/data/101/804/879/101804879.geojson
@@ -131,6 +131,9 @@
         "wk:page":"Trim, County Meath"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"417c57a0fa56fc9b4d0acbcadc3180f0",
     "wof:hierarchy":[
         {
@@ -141,7 +144,7 @@
         }
     ],
     "wof:id":101804879,
-    "wof:lastmodified":1566680103,
+    "wof:lastmodified":1582356305,
     "wof:name":"Trim",
     "wof:parent_id":85685081,
     "wof:placetype":"locality",

--- a/data/101/804/883/101804883.geojson
+++ b/data/101/804/883/101804883.geojson
@@ -111,6 +111,9 @@
         "wk:page":"Slane"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c25527dec1da7f348e482b4c22b3ffe8",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566680103,
+    "wof:lastmodified":1582356305,
     "wof:name":"Slane",
     "wof:parent_id":85685081,
     "wof:placetype":"locality",

--- a/data/101/804/885/101804885.geojson
+++ b/data/101/804/885/101804885.geojson
@@ -111,6 +111,9 @@
         "wk:page":"Duleek"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7ec1148c11bcd2d5b4d34b77aa206f7d",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566680104,
+    "wof:lastmodified":1582356305,
     "wof:name":"Duleek",
     "wof:parent_id":85685081,
     "wof:placetype":"locality",

--- a/data/101/804/887/101804887.geojson
+++ b/data/101/804/887/101804887.geojson
@@ -87,6 +87,9 @@
         "wk:page":"Julianstown"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"dfc02f40c0dad84c4b4b819a9044aa5b",
     "wof:hierarchy":[
         {
@@ -100,7 +103,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566680097,
+    "wof:lastmodified":1582356304,
     "wof:name":"Julianstown",
     "wof:parent_id":85685081,
     "wof:placetype":"locality",

--- a/data/101/804/899/101804899.geojson
+++ b/data/101/804/899/101804899.geojson
@@ -107,6 +107,9 @@
         "wk:page":"Enfield, County Meath"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"fb14bdcbc39c217f61e1a3bb8c4b6a92",
     "wof:hierarchy":[
         {
@@ -120,7 +123,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566680105,
+    "wof:lastmodified":1582356306,
     "wof:name":"Innfield",
     "wof:parent_id":85685081,
     "wof:placetype":"locality",

--- a/data/101/804/901/101804901.geojson
+++ b/data/101/804/901/101804901.geojson
@@ -84,6 +84,9 @@
         "qs_pg:id":972508
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b703fb57ea5d082e09acbbc9ee660271",
     "wof:hierarchy":[
         {
@@ -94,7 +97,7 @@
         }
     ],
     "wof:id":101804901,
-    "wof:lastmodified":1566680095,
+    "wof:lastmodified":1582356304,
     "wof:name":"Kentstown",
     "wof:parent_id":85685081,
     "wof:placetype":"locality",

--- a/data/101/804/903/101804903.geojson
+++ b/data/101/804/903/101804903.geojson
@@ -90,6 +90,9 @@
         "wk:page":"Carlingford, County Louth"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"df6708a60b2870cbc0f0c6d8b1aa68a8",
     "wof:hierarchy":[
         {
@@ -103,7 +106,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566680102,
+    "wof:lastmodified":1582356305,
     "wof:name":"Carlingford",
     "wof:parent_id":85685087,
     "wof:placetype":"locality",

--- a/data/101/804/909/101804909.geojson
+++ b/data/101/804/909/101804909.geojson
@@ -94,6 +94,9 @@
         "wk:page":"Dunleer"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"fba660cf51552794d8c3e458e150e800",
     "wof:hierarchy":[
         {
@@ -107,7 +110,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566680094,
+    "wof:lastmodified":1582356304,
     "wof:name":"Dunleer",
     "wof:parent_id":85685087,
     "wof:placetype":"locality",

--- a/data/101/804/911/101804911.geojson
+++ b/data/101/804/911/101804911.geojson
@@ -122,6 +122,9 @@
         "wk:page":"Ardee"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d2ab1062e7abb3dd7e94b5bab87d29f3",
     "wof:hierarchy":[
         {
@@ -132,7 +135,7 @@
         }
     ],
     "wof:id":101804911,
-    "wof:lastmodified":1566680106,
+    "wof:lastmodified":1582356306,
     "wof:name":"Ardee",
     "wof:parent_id":85685087,
     "wof:placetype":"locality",

--- a/data/101/804/917/101804917.geojson
+++ b/data/101/804/917/101804917.geojson
@@ -292,6 +292,9 @@
         "wk:page":"Drogheda"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7f8ce26fa03c08d5e20b70c98b1830c3",
     "wof:hierarchy":[
         {
@@ -302,7 +305,7 @@
         }
     ],
     "wof:id":101804917,
-    "wof:lastmodified":1566680107,
+    "wof:lastmodified":1582356306,
     "wof:name":"Drogheda",
     "wof:parent_id":85685087,
     "wof:placetype":"locality",

--- a/data/101/804/919/101804919.geojson
+++ b/data/101/804/919/101804919.geojson
@@ -90,6 +90,9 @@
         "wk:page":"Clogherhead"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6fa8439dc3552874ce3b1ffb7b10eb3b",
     "wof:hierarchy":[
         {
@@ -103,7 +106,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566680107,
+    "wof:lastmodified":1582356306,
     "wof:name":"Clogherhead",
     "wof:parent_id":85685087,
     "wof:placetype":"locality",

--- a/data/101/804/923/101804923.geojson
+++ b/data/101/804/923/101804923.geojson
@@ -104,6 +104,9 @@
         "wk:page":"Granard"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"340a05000dee325bfeca82c2cd13c228",
     "wof:hierarchy":[
         {
@@ -114,7 +117,7 @@
         }
     ],
     "wof:id":101804923,
-    "wof:lastmodified":1566680100,
+    "wof:lastmodified":1582356305,
     "wof:name":"Granard",
     "wof:parent_id":85685091,
     "wof:placetype":"locality",

--- a/data/101/804/933/101804933.geojson
+++ b/data/101/804/933/101804933.geojson
@@ -137,6 +137,9 @@
         "wk:page":"Ballinasloe"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d8914e267a77c43e638ee8fc98ccea87",
     "wof:hierarchy":[
         {
@@ -147,7 +150,7 @@
         }
     ],
     "wof:id":101804933,
-    "wof:lastmodified":1566680103,
+    "wof:lastmodified":1582356305,
     "wof:name":"Ballinasloe",
     "wof:parent_id":85685097,
     "wof:placetype":"locality",

--- a/data/101/804/969/101804969.geojson
+++ b/data/101/804/969/101804969.geojson
@@ -115,6 +115,9 @@
         "wk:page":"Boyle, County Roscommon"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"65d35f30b35236fc1ac4d8011205efe8",
     "wof:hierarchy":[
         {
@@ -125,7 +128,7 @@
         }
     ],
     "wof:id":101804969,
-    "wof:lastmodified":1566680103,
+    "wof:lastmodified":1582356305,
     "wof:name":"Boyle",
     "wof:parent_id":85685113,
     "wof:placetype":"locality",

--- a/data/101/804/971/101804971.geojson
+++ b/data/101/804/971/101804971.geojson
@@ -249,6 +249,9 @@
         "qs_pg:id":1327427
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c3cab9710ce4bd7ea6686c5d48643e6f",
     "wof:hierarchy":[
         {
@@ -259,7 +262,7 @@
         }
     ],
     "wof:id":101804971,
-    "wof:lastmodified":1566680101,
+    "wof:lastmodified":1582356305,
     "wof:name":"Roscommon",
     "wof:parent_id":85685113,
     "wof:placetype":"locality",

--- a/data/101/804/975/101804975.geojson
+++ b/data/101/804/975/101804975.geojson
@@ -122,6 +122,9 @@
         "wk:page":"Carrickmacross"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ac8317e31e76c79d630059b34c036c87",
     "wof:hierarchy":[
         {
@@ -132,7 +135,7 @@
         }
     ],
     "wof:id":101804975,
-    "wof:lastmodified":1566680108,
+    "wof:lastmodified":1582356306,
     "wof:name":"Carrickmacross",
     "wof:parent_id":85685117,
     "wof:placetype":"locality",

--- a/data/101/804/977/101804977.geojson
+++ b/data/101/804/977/101804977.geojson
@@ -90,6 +90,9 @@
         "wk:page":"Inniskeen"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"47abca3ec56d24bd3ecf4a9b87f509fa",
     "wof:hierarchy":[
         {
@@ -103,7 +106,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566680099,
+    "wof:lastmodified":1582356304,
     "wof:name":"Inishkeen",
     "wof:parent_id":85685117,
     "wof:placetype":"locality",

--- a/data/101/804/979/101804979.geojson
+++ b/data/101/804/979/101804979.geojson
@@ -84,6 +84,9 @@
         "wk:page":"Emyvale"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e8e440c78eb39225fcb2a21e38272579",
     "wof:hierarchy":[
         {
@@ -97,7 +100,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566680099,
+    "wof:lastmodified":1582356305,
     "wof:name":"Emyvale",
     "wof:parent_id":85685117,
     "wof:placetype":"locality",

--- a/data/101/804/981/101804981.geojson
+++ b/data/101/804/981/101804981.geojson
@@ -247,6 +247,9 @@
         "wk:page":"Monaghan"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"92964cccba9ff6243e2b85c02c03594a",
     "wof:hierarchy":[
         {
@@ -257,7 +260,7 @@
         }
     ],
     "wof:id":101804981,
-    "wof:lastmodified":1566680108,
+    "wof:lastmodified":1582356306,
     "wof:name":"Monaghan",
     "wof:parent_id":85685117,
     "wof:placetype":"locality",

--- a/data/101/804/983/101804983.geojson
+++ b/data/101/804/983/101804983.geojson
@@ -111,6 +111,9 @@
         "wk:page":"Clones"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"af573a76c7746b6eb4eb848fd969936c",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566680099,
+    "wof:lastmodified":1582356305,
     "wof:name":"Clones",
     "wof:parent_id":85685117,
     "wof:placetype":"locality",

--- a/data/101/804/989/101804989.geojson
+++ b/data/101/804/989/101804989.geojson
@@ -95,6 +95,9 @@
         "wk:page":"Castleblayney"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3011302ed24d6aa787e58365d3a66dc8",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
         }
     ],
     "wof:id":101804989,
-    "wof:lastmodified":1566680106,
+    "wof:lastmodified":1582356306,
     "wof:name":"Castleblayney",
     "wof:parent_id":85685117,
     "wof:placetype":"locality",

--- a/data/101/804/991/101804991.geojson
+++ b/data/101/804/991/101804991.geojson
@@ -108,6 +108,9 @@
         "wk:page":"Kingscourt"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"32f5abaa70686ca2d89c8d612510f260",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566680095,
+    "wof:lastmodified":1582356304,
     "wof:name":"Kingscourt",
     "wof:parent_id":85685125,
     "wof:placetype":"locality",

--- a/data/101/804/999/101804999.geojson
+++ b/data/101/804/999/101804999.geojson
@@ -175,6 +175,9 @@
         "qs_pg:id":1078374
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b318bfa19602f81dc1f92e4c212dd364",
     "wof:hierarchy":[
         {
@@ -185,7 +188,7 @@
         }
     ],
     "wof:id":101804999,
-    "wof:lastmodified":1566680096,
+    "wof:lastmodified":1582356304,
     "wof:name":"Cavan",
     "wof:parent_id":85685125,
     "wof:placetype":"locality",

--- a/data/101/805/009/101805009.geojson
+++ b/data/101/805/009/101805009.geojson
@@ -101,6 +101,9 @@
         "wk:page":"Cootehill"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7acbf1167c879a847f3c2309c748801a",
     "wof:hierarchy":[
         {
@@ -111,7 +114,7 @@
         }
     ],
     "wof:id":101805009,
-    "wof:lastmodified":1566680114,
+    "wof:lastmodified":1582356307,
     "wof:name":"Cootehill",
     "wof:parent_id":85685125,
     "wof:placetype":"locality",

--- a/data/101/805/019/101805019.geojson
+++ b/data/101/805/019/101805019.geojson
@@ -308,6 +308,9 @@
         "wk:page":"Sligo"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"37d8d1ac17300e10e0e0b3f98293209d",
     "wof:hierarchy":[
         {
@@ -318,7 +321,7 @@
         }
     ],
     "wof:id":101805019,
-    "wof:lastmodified":1566680119,
+    "wof:lastmodified":1582356307,
     "wof:name":"Sligo",
     "wof:parent_id":85685137,
     "wof:placetype":"locality",

--- a/data/101/805/023/101805023.geojson
+++ b/data/101/805/023/101805023.geojson
@@ -108,6 +108,9 @@
         "wk:page":"Ballymote"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"56cf69eefac9f53733755f6709b803ee",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566680110,
+    "wof:lastmodified":1582356306,
     "wof:name":"Ballymote",
     "wof:parent_id":85685137,
     "wof:placetype":"locality",

--- a/data/101/805/025/101805025.geojson
+++ b/data/101/805/025/101805025.geojson
@@ -114,6 +114,9 @@
         "wk:page":"Tubbercurry"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a6a04003f34f839c0e8209e49462f062",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566680112,
+    "wof:lastmodified":1582356306,
     "wof:name":"Tobercurry",
     "wof:parent_id":85685137,
     "wof:placetype":"locality",

--- a/data/101/805/029/101805029.geojson
+++ b/data/101/805/029/101805029.geojson
@@ -96,6 +96,9 @@
         "wk:page":"Collooney"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"015d138827f765ba744b8f63d2ca80a3",
     "wof:hierarchy":[
         {
@@ -109,7 +112,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566680119,
+    "wof:lastmodified":1582356307,
     "wof:name":"Collooney",
     "wof:parent_id":85685137,
     "wof:placetype":"locality",

--- a/data/101/805/031/101805031.geojson
+++ b/data/101/805/031/101805031.geojson
@@ -169,6 +169,9 @@
         "wk:page":"Ballina, County Mayo"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"da3a9c874f8774189db56e4676202773",
     "wof:hierarchy":[
         {
@@ -179,7 +182,7 @@
         }
     ],
     "wof:id":101805031,
-    "wof:lastmodified":1566680114,
+    "wof:lastmodified":1582356307,
     "wof:name":"Ballina",
     "wof:parent_id":85685145,
     "wof:placetype":"locality",

--- a/data/101/805/043/101805043.geojson
+++ b/data/101/805/043/101805043.geojson
@@ -178,6 +178,9 @@
         "wk:page":"Castlebar"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"31f3ef6921cf30d436ba8d8a95427cc1",
     "wof:hierarchy":[
         {
@@ -188,7 +191,7 @@
         }
     ],
     "wof:id":101805043,
-    "wof:lastmodified":1566680119,
+    "wof:lastmodified":1582356307,
     "wof:name":"Castlebar",
     "wof:parent_id":85685145,
     "wof:placetype":"locality",

--- a/data/101/805/091/101805091.geojson
+++ b/data/101/805/091/101805091.geojson
@@ -145,6 +145,9 @@
         "wk:page":"Ballyshannon"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ce12dfdff73411f0f91f8e9350fda497",
     "wof:hierarchy":[
         {
@@ -155,7 +158,7 @@
         }
     ],
     "wof:id":101805091,
-    "wof:lastmodified":1566680113,
+    "wof:lastmodified":1582356306,
     "wof:name":"Ballyshannon",
     "wof:parent_id":85685151,
     "wof:placetype":"locality",

--- a/data/101/805/851/101805851.geojson
+++ b/data/101/805/851/101805851.geojson
@@ -175,6 +175,9 @@
         "qs_pg:id":1040401
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"eb11df5e5dd4c0fceee47535f8a96a22",
     "wof:hierarchy":[
         {
@@ -185,7 +188,7 @@
         }
     ],
     "wof:id":101805851,
-    "wof:lastmodified":1566680114,
+    "wof:lastmodified":1582356307,
     "wof:name":"Navan",
     "wof:parent_id":85685081,
     "wof:placetype":"locality",

--- a/data/101/805/853/101805853.geojson
+++ b/data/101/805/853/101805853.geojson
@@ -281,6 +281,9 @@
         "wk:page":"Waterford"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7bfb769102ca7c35a29dcc8454f875a7",
     "wof:hierarchy":[
         {
@@ -291,7 +294,7 @@
         }
     ],
     "wof:id":101805853,
-    "wof:lastmodified":1566680120,
+    "wof:lastmodified":1582356307,
     "wof:name":"Waterford",
     "wof:parent_id":85684953,
     "wof:placetype":"locality",

--- a/data/101/805/879/101805879.geojson
+++ b/data/101/805/879/101805879.geojson
@@ -148,6 +148,9 @@
         "wk:page":"Mallow, County Cork"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a50c4bd462e530be2360fcb2e8780f7a",
     "wof:hierarchy":[
         {
@@ -158,7 +161,7 @@
         }
     ],
     "wof:id":101805879,
-    "wof:lastmodified":1566680118,
+    "wof:lastmodified":1582356307,
     "wof:name":"Mallow",
     "wof:parent_id":85684963,
     "wof:placetype":"locality",

--- a/data/101/805/893/101805893.geojson
+++ b/data/101/805/893/101805893.geojson
@@ -119,6 +119,9 @@
         "wk:page":"Midleton"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d7da656d9562231abef940151ae84fab",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
         }
     ],
     "wof:id":101805893,
-    "wof:lastmodified":1566680115,
+    "wof:lastmodified":1582356307,
     "wof:name":"Middleton",
     "wof:parent_id":85684963,
     "wof:placetype":"locality",

--- a/data/101/805/897/101805897.geojson
+++ b/data/101/805/897/101805897.geojson
@@ -162,6 +162,9 @@
         "wk:page":"Kinsale"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"81ae7a316f4212b521b447cb8dbb2034",
     "wof:hierarchy":[
         {
@@ -172,7 +175,7 @@
         }
     ],
     "wof:id":101805897,
-    "wof:lastmodified":1566680121,
+    "wof:lastmodified":1582356307,
     "wof:name":"Kinsale",
     "wof:parent_id":85684963,
     "wof:placetype":"locality",

--- a/data/101/805/913/101805913.geojson
+++ b/data/101/805/913/101805913.geojson
@@ -137,6 +137,9 @@
         "wk:page":"Clonakilty"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6d55b33a01074e3cb4c3406aa8fd3a33",
     "wof:hierarchy":[
         {
@@ -147,7 +150,7 @@
         }
     ],
     "wof:id":101805913,
-    "wof:lastmodified":1566680116,
+    "wof:lastmodified":1582356307,
     "wof:name":"Clonakilty",
     "wof:parent_id":85684963,
     "wof:placetype":"locality",

--- a/data/101/805/917/101805917.geojson
+++ b/data/101/805/917/101805917.geojson
@@ -98,6 +98,9 @@
         "wk:page":"Dunmanway"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5927ad1f10a20c9001e77be55bdeb0d2",
     "wof:hierarchy":[
         {
@@ -108,7 +111,7 @@
         }
     ],
     "wof:id":101805917,
-    "wof:lastmodified":1566680122,
+    "wof:lastmodified":1582356307,
     "wof:name":"Dunmanway",
     "wof:parent_id":85684963,
     "wof:placetype":"locality",

--- a/data/101/805/933/101805933.geojson
+++ b/data/101/805/933/101805933.geojson
@@ -128,6 +128,9 @@
         "wk:page":"Gorey"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7743f9e75e26d6cac13749cd10892a93",
     "wof:hierarchy":[
         {
@@ -138,7 +141,7 @@
         }
     ],
     "wof:id":101805933,
-    "wof:lastmodified":1566680118,
+    "wof:lastmodified":1582356307,
     "wof:name":"Gorey",
     "wof:parent_id":85684967,
     "wof:placetype":"locality",

--- a/data/101/805/937/101805937.geojson
+++ b/data/101/805/937/101805937.geojson
@@ -128,6 +128,9 @@
         "wk:page":"New Ross"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8408adba9d9ec6c591234eb060414e4d",
     "wof:hierarchy":[
         {
@@ -138,7 +141,7 @@
         }
     ],
     "wof:id":101805937,
-    "wof:lastmodified":1566680110,
+    "wof:lastmodified":1582356306,
     "wof:name":"New Ross",
     "wof:parent_id":85684967,
     "wof:placetype":"locality",

--- a/data/101/805/941/101805941.geojson
+++ b/data/101/805/941/101805941.geojson
@@ -173,6 +173,9 @@
         "wd:id":"Q209126"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"363f1fb51e9204e8ef545f5bb5ad9018",
     "wof:hierarchy":[
         {
@@ -183,7 +186,7 @@
         }
     ],
     "wof:id":101805941,
-    "wof:lastmodified":1566680115,
+    "wof:lastmodified":1582356307,
     "wof:name":"Wexford",
     "wof:parent_id":85684967,
     "wof:placetype":"locality",

--- a/data/101/805/945/101805945.geojson
+++ b/data/101/805/945/101805945.geojson
@@ -125,6 +125,9 @@
         "wk:page":"Carrick-on-Suir"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f4a3f0354aae88fc51661abfb2fcfcd2",
     "wof:hierarchy":[
         {
@@ -135,7 +138,7 @@
         }
     ],
     "wof:id":101805945,
-    "wof:lastmodified":1566680122,
+    "wof:lastmodified":1582356307,
     "wof:name":"Carrick-on-Suir",
     "wof:parent_id":1159294375,
     "wof:placetype":"locality",

--- a/data/101/805/953/101805953.geojson
+++ b/data/101/805/953/101805953.geojson
@@ -122,6 +122,9 @@
         "wk:page":"Cahir"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9711a1d3a74bc1dc546874b8fb9a783d",
     "wof:hierarchy":[
         {
@@ -132,7 +135,7 @@
         }
     ],
     "wof:id":101805953,
-    "wof:lastmodified":1566680109,
+    "wof:lastmodified":1582356306,
     "wof:name":"Caher",
     "wof:parent_id":1159294375,
     "wof:placetype":"locality",

--- a/data/101/805/955/101805955.geojson
+++ b/data/101/805/955/101805955.geojson
@@ -182,6 +182,9 @@
         "wk:page":"Clonmel"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"85b209f3cee0d20d0f84786260ebfdd5",
     "wof:hierarchy":[
         {
@@ -192,7 +195,7 @@
         }
     ],
     "wof:id":101805955,
-    "wof:lastmodified":1566680110,
+    "wof:lastmodified":1582356306,
     "wof:name":"Clonmel",
     "wof:parent_id":1159294375,
     "wof:placetype":"locality",

--- a/data/101/805/959/101805959.geojson
+++ b/data/101/805/959/101805959.geojson
@@ -84,6 +84,9 @@
         "wk:page":"Hacketstown"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"187dbcb66c1211a6051f57851dab3003",
     "wof:hierarchy":[
         {
@@ -97,7 +100,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566680117,
+    "wof:lastmodified":1582356307,
     "wof:name":"Hacketstown",
     "wof:parent_id":85684975,
     "wof:placetype":"locality",

--- a/data/101/805/961/101805961.geojson
+++ b/data/101/805/961/101805961.geojson
@@ -111,6 +111,9 @@
         "wk:page":"Tullow"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6d1413ff0553fb0a34fb1a1d70ed405d",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566680116,
+    "wof:lastmodified":1582356307,
     "wof:name":"Tullow",
     "wof:parent_id":85684975,
     "wof:placetype":"locality",

--- a/data/101/805/963/101805963.geojson
+++ b/data/101/805/963/101805963.geojson
@@ -173,6 +173,9 @@
         "qs_pg:id":1336074
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2a04fc5322895589d62d94c0d1706396",
     "wof:hierarchy":[
         {
@@ -183,7 +186,7 @@
         }
     ],
     "wof:id":101805963,
-    "wof:lastmodified":1566680110,
+    "wof:lastmodified":1582356306,
     "wof:name":"Carlow",
     "wof:parent_id":85684975,
     "wof:placetype":"locality",

--- a/data/101/805/965/101805965.geojson
+++ b/data/101/805/965/101805965.geojson
@@ -96,6 +96,9 @@
         "wk:page":"Leighlinbridge"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f64013bc9ee33a8c1a748e13366df313",
     "wof:hierarchy":[
         {
@@ -109,7 +112,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566680109,
+    "wof:lastmodified":1582356306,
     "wof:name":"Leighlinbridge",
     "wof:parent_id":85684975,
     "wof:placetype":"locality",

--- a/data/101/805/967/101805967.geojson
+++ b/data/101/805/967/101805967.geojson
@@ -122,6 +122,9 @@
         "wk:page":"Muine Bheag"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8f41ff1f92aa6cab02e848e9eddaa92b",
     "wof:hierarchy":[
         {
@@ -132,7 +135,7 @@
         }
     ],
     "wof:id":101805967,
-    "wof:lastmodified":1566680117,
+    "wof:lastmodified":1582356307,
     "wof:name":"Bagenalstown",
     "wof:parent_id":85684975,
     "wof:placetype":"locality",

--- a/data/101/805/969/101805969.geojson
+++ b/data/101/805/969/101805969.geojson
@@ -90,6 +90,9 @@
         "wk:page":"Castlecomer"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"de4fb35a91b26bb57d9cb818e0b208b2",
     "wof:hierarchy":[
         {
@@ -103,7 +106,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566680117,
+    "wof:lastmodified":1582356307,
     "wof:name":"Castlecomer",
     "wof:parent_id":85684979,
     "wof:placetype":"locality",

--- a/data/101/805/973/101805973.geojson
+++ b/data/101/805/973/101805973.geojson
@@ -78,6 +78,9 @@
         "wk:page":"Freshford, County Kilkenny"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"55bbd58815b860e718b7f3c1c7efffe1",
     "wof:hierarchy":[
         {
@@ -91,7 +94,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566680122,
+    "wof:lastmodified":1582356307,
     "wof:name":"Freshford",
     "wof:parent_id":85684979,
     "wof:placetype":"locality",

--- a/data/101/805/977/101805977.geojson
+++ b/data/101/805/977/101805977.geojson
@@ -308,6 +308,9 @@
         "wk:page":"Kilkenny"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ba3a6f3411e7222868d81c1221a6e2fd",
     "wof:hierarchy":[
         {
@@ -321,7 +324,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566680115,
+    "wof:lastmodified":1582356307,
     "wof:name":"Kilkenny",
     "wof:parent_id":85684979,
     "wof:placetype":"locality",

--- a/data/101/805/979/101805979.geojson
+++ b/data/101/805/979/101805979.geojson
@@ -110,6 +110,9 @@
         "wk:page":"Callan, County Kilkenny"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"dbfddda75ecdd41ede3405635888d6e9",
     "wof:hierarchy":[
         {
@@ -120,7 +123,7 @@
         }
     ],
     "wof:id":101805979,
-    "wof:lastmodified":1566680115,
+    "wof:lastmodified":1582356307,
     "wof:name":"Callan",
     "wof:parent_id":85684979,
     "wof:placetype":"locality",

--- a/data/101/806/021/101806021.geojson
+++ b/data/101/806/021/101806021.geojson
@@ -269,6 +269,9 @@
         "qs_pg:id":1238102
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2a522e7bb2b77335f78b1868c1e79eda",
     "wof:hierarchy":[
         {
@@ -279,7 +282,7 @@
         }
     ],
     "wof:id":101806021,
-    "wof:lastmodified":1566680128,
+    "wof:lastmodified":1582356309,
     "wof:name":"Tralee",
     "wof:parent_id":85684991,
     "wof:placetype":"locality",

--- a/data/101/806/027/101806027.geojson
+++ b/data/101/806/027/101806027.geojson
@@ -116,6 +116,9 @@
         "wk:page":"Cahersiveen"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b04a443ad7472f395c14df280ef34c6a",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
         }
     ],
     "wof:id":101806027,
-    "wof:lastmodified":1566680128,
+    "wof:lastmodified":1582356308,
     "wof:name":"Cahersiveen",
     "wof:parent_id":85684991,
     "wof:placetype":"locality",

--- a/data/101/806/031/101806031.geojson
+++ b/data/101/806/031/101806031.geojson
@@ -165,6 +165,9 @@
         "wk:page":"Wicklow"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"cd71dd825610f45a6e0f5b17bec7e69d",
     "wof:hierarchy":[
         {
@@ -175,7 +178,7 @@
         }
     ],
     "wof:id":101806031,
-    "wof:lastmodified":1566680127,
+    "wof:lastmodified":1582356308,
     "wof:name":"Wicklow",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/101/806/043/101806043.geojson
+++ b/data/101/806/043/101806043.geojson
@@ -143,6 +143,9 @@
         "wk:page":"Thurles"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3969398a1519794080804de7fa301fce",
     "wof:hierarchy":[
         {
@@ -153,7 +156,7 @@
         }
     ],
     "wof:id":101806043,
-    "wof:lastmodified":1566680128,
+    "wof:lastmodified":1582356308,
     "wof:name":"Thurles",
     "wof:parent_id":1159294375,
     "wof:placetype":"locality",

--- a/data/101/837/621/101837621.geojson
+++ b/data/101/837/621/101837621.geojson
@@ -85,6 +85,9 @@
         "wk:page":"Delgany"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f73042bb6aa9f53f38358621467d7e53",
     "wof:hierarchy":[
         {
@@ -98,7 +101,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566680126,
+    "wof:lastmodified":1582356308,
     "wof:name":"Delgany",
     "wof:parent_id":85684999,
     "wof:placetype":"locality",

--- a/data/101/837/623/101837623.geojson
+++ b/data/101/837/623/101837623.geojson
@@ -176,6 +176,9 @@
         "qs_pg:id":1078456
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4ff559ebfbb32311da4fa03c8321da2d",
     "wof:hierarchy":[
         {
@@ -186,7 +189,7 @@
         }
     ],
     "wof:id":101837623,
-    "wof:lastmodified":1566680126,
+    "wof:lastmodified":1582356308,
     "wof:name":"Naas",
     "wof:parent_id":85685025,
     "wof:placetype":"locality",

--- a/data/101/837/625/101837625.geojson
+++ b/data/101/837/625/101837625.geojson
@@ -92,6 +92,9 @@
         "wk:page":"Kill, County Kildare"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"190a0807f08ce8e4817481651c95c028",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566680126,
+    "wof:lastmodified":1582356308,
     "wof:name":"Kill",
     "wof:parent_id":85685025,
     "wof:placetype":"locality",

--- a/data/101/837/627/101837627.geojson
+++ b/data/101/837/627/101837627.geojson
@@ -285,7 +285,8 @@
     "qs:type":"rural point-multi-in-poly-resolved",
     "src:geom":"quattroshapes",
     "src:geom_alt":[
-        "quattroshapes_pg"
+        "quattroshapes_pg",
+        "naturalearth"
     ],
     "src:lbl_centroid":"mapshaper",
     "src:population":"geonames",
@@ -306,6 +307,10 @@
         "wk:page":"Dundalk"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "naturalearth"
+    ],
     "wof:geomhash":"885137eab91500c4f98c52e10125274e",
     "wof:hierarchy":[
         {
@@ -316,7 +321,7 @@
         }
     ],
     "wof:id":101837627,
-    "wof:lastmodified":1566680126,
+    "wof:lastmodified":1582356308,
     "wof:name":"Dundalk",
     "wof:parent_id":85685087,
     "wof:placetype":"locality",

--- a/data/101/845/617/101845617.geojson
+++ b/data/101/845/617/101845617.geojson
@@ -81,6 +81,9 @@
         "wk:page":"Piltown"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"62b7dae47a39e0af3b1cfa4801e49d73",
     "wof:hierarchy":[
         {
@@ -94,7 +97,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566680092,
+    "wof:lastmodified":1582356303,
     "wof:name":"Piltown",
     "wof:parent_id":85684979,
     "wof:placetype":"locality",

--- a/data/101/845/621/101845621.geojson
+++ b/data/101/845/621/101845621.geojson
@@ -90,6 +90,9 @@
         "wk:page":"Straffan"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"bd3745ae7e890783c933b63b9468337f",
     "wof:hierarchy":[
         {
@@ -103,7 +106,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566680092,
+    "wof:lastmodified":1582356303,
     "wof:name":"Straffan",
     "wof:parent_id":85685025,
     "wof:placetype":"locality",

--- a/data/101/847/095/101847095.geojson
+++ b/data/101/847/095/101847095.geojson
@@ -160,6 +160,9 @@
         "qs_pg:id":1327408
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"48293920a5701720d44c05c78f413df9",
     "wof:hierarchy":[
         {
@@ -170,7 +173,7 @@
         }
     ],
     "wof:id":101847095,
-    "wof:lastmodified":1566680124,
+    "wof:lastmodified":1582356308,
     "wof:name":"Lifford",
     "wof:parent_id":85685151,
     "wof:placetype":"locality",

--- a/data/101/853/141/101853141.geojson
+++ b/data/101/853/141/101853141.geojson
@@ -147,6 +147,9 @@
         "wk:page":"Lapugnoy"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3883ec267063e1d3fd4145fb2769222c",
     "wof:hierarchy":[
         {
@@ -160,7 +163,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566680125,
+    "wof:lastmodified":1582356308,
     "wof:name":"Clonea",
     "wof:parent_id":85684953,
     "wof:placetype":"locality",

--- a/data/101/853/143/101853143.geojson
+++ b/data/101/853/143/101853143.geojson
@@ -82,6 +82,9 @@
         "wk:page":"Ballygarvan, County Cork"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e59622b46643ef75c9739b4e9911fab1",
     "wof:hierarchy":[
         {
@@ -95,7 +98,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566680125,
+    "wof:lastmodified":1582356308,
     "wof:name":"Ballygarvan",
     "wof:parent_id":85684963,
     "wof:placetype":"locality",

--- a/data/101/853/145/101853145.geojson
+++ b/data/101/853/145/101853145.geojson
@@ -73,6 +73,9 @@
         "wk:page":"Carrignavar"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7e981c574cc46a84de12ab4f7a66ca48",
     "wof:hierarchy":[
         {
@@ -86,7 +89,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566680125,
+    "wof:lastmodified":1582356308,
     "wof:name":"Carrignavar",
     "wof:parent_id":85684963,
     "wof:placetype":"locality",

--- a/data/101/853/147/101853147.geojson
+++ b/data/101/853/147/101853147.geojson
@@ -49,6 +49,9 @@
         "qs_pg:id":9
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"24ab0ce3ec88a5fa5ac3dc25bc773918",
     "wof:hierarchy":[
         {
@@ -59,7 +62,7 @@
         }
     ],
     "wof:id":101853147,
-    "wof:lastmodified":1566680125,
+    "wof:lastmodified":1582356308,
     "wof:name":"Matehy",
     "wof:parent_id":85684963,
     "wof:placetype":"locality",

--- a/data/101/853/149/101853149.geojson
+++ b/data/101/853/149/101853149.geojson
@@ -79,6 +79,9 @@
         "wk:page":"Clonroche"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f9cdf597411c10d9a015c530a4f327cc",
     "wof:hierarchy":[
         {
@@ -92,7 +95,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566680126,
+    "wof:lastmodified":1582356308,
     "wof:name":"Clonroche",
     "wof:parent_id":85684967,
     "wof:placetype":"locality",

--- a/data/101/853/151/101853151.geojson
+++ b/data/101/853/151/101853151.geojson
@@ -69,6 +69,9 @@
         "wd:id":"Q4220555"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5a4fd645dbd3b69500061abefcd5ac4c",
     "wof:hierarchy":[
         {
@@ -79,7 +82,7 @@
         }
     ],
     "wof:id":101853151,
-    "wof:lastmodified":1566680125,
+    "wof:lastmodified":1582356308,
     "wof:name":"Kilmore",
     "wof:parent_id":85684967,
     "wof:placetype":"locality",

--- a/data/101/853/155/101853155.geojson
+++ b/data/101/853/155/101853155.geojson
@@ -77,6 +77,9 @@
         "wk:page":"Ballyhack, County Wexford"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f7c491131eb449d19bbb03781209f007",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566680125,
+    "wof:lastmodified":1582356308,
     "wof:name":"Ballyhack",
     "wof:parent_id":85684967,
     "wof:placetype":"locality",

--- a/data/101/853/157/101853157.geojson
+++ b/data/101/853/157/101853157.geojson
@@ -74,6 +74,9 @@
         "qs_pg:id":1158758
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"57366a9ac9b4a6044fa7dfff13472553",
     "wof:hierarchy":[
         {
@@ -87,7 +90,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566680124,
+    "wof:lastmodified":1582356308,
     "wof:name":"Kilcummin",
     "wof:parent_id":85684991,
     "wof:placetype":"locality",

--- a/data/101/853/159/101853159.geojson
+++ b/data/101/853/159/101853159.geojson
@@ -94,6 +94,9 @@
         "wk:page":"Ballyheigue"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9d47474d605c86cee91f2e8953e7c9d5",
     "wof:hierarchy":[
         {
@@ -107,7 +110,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566680125,
+    "wof:lastmodified":1582356308,
     "wof:name":"Ballyheige",
     "wof:parent_id":85684991,
     "wof:placetype":"locality",

--- a/data/101/853/673/101853673.geojson
+++ b/data/101/853/673/101853673.geojson
@@ -67,6 +67,9 @@
         "wk:page":"La Chapelle-Moutils"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5ebfbd431f7fad88d80e80a633855c1e",
     "wof:hierarchy":[
         {
@@ -80,7 +83,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566680125,
+    "wof:lastmodified":1582356308,
     "wof:name":"Fedamore",
     "wof:parent_id":85684987,
     "wof:placetype":"locality",

--- a/data/101/853/677/101853677.geojson
+++ b/data/101/853/677/101853677.geojson
@@ -285,6 +285,9 @@
         "wk:page":"Sarrant"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b4df423efbccd94a16cd607df8f57a62",
     "wof:hierarchy":[
         {
@@ -295,7 +298,7 @@
         }
     ],
     "wof:id":101853677,
-    "wof:lastmodified":1566680125,
+    "wof:lastmodified":1582356308,
     "wof:name":"Littleton",
     "wof:parent_id":1159294375,
     "wof:placetype":"locality",

--- a/data/101/872/745/101872745.geojson
+++ b/data/101/872/745/101872745.geojson
@@ -81,6 +81,9 @@
         "wd:id":"Q2546895"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7a6e05685d7f803b4b249078142ff3dd",
     "wof:hierarchy":[
         {
@@ -94,7 +97,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566680094,
+    "wof:lastmodified":1582356304,
     "wof:name":"Kilmacanoge",
     "wof:parent_id":85684999,
     "wof:placetype":"locality",

--- a/data/101/872/747/101872747.geojson
+++ b/data/101/872/747/101872747.geojson
@@ -113,6 +113,10 @@
         "wk:page":"Kilcock"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a9ddb5419618a48d418f0752a4feb5b2",
     "wof:hierarchy":[
         {
@@ -126,7 +130,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566680093,
+    "wof:lastmodified":1582356303,
     "wof:name":"Kilcock",
     "wof:parent_id":85685025,
     "wof:placetype":"locality",

--- a/data/101/872/749/101872749.geojson
+++ b/data/101/872/749/101872749.geojson
@@ -82,6 +82,9 @@
         "wk:page":"Killeigh"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"72babf785155482f21f9f8bd8bd10d30",
     "wof:hierarchy":[
         {
@@ -95,7 +98,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566680093,
+    "wof:lastmodified":1582356303,
     "wof:name":"Killeigh",
     "wof:parent_id":85685041,
     "wof:placetype":"locality",

--- a/data/101/872/751/101872751.geojson
+++ b/data/101/872/751/101872751.geojson
@@ -49,6 +49,9 @@
         "qs_pg:id":1
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bdb98fb104a3ed29ae14b401a62901d0",
     "wof:hierarchy":[
         {
@@ -59,7 +62,7 @@
         }
     ],
     "wof:id":101872751,
-    "wof:lastmodified":1566680094,
+    "wof:lastmodified":1582356303,
     "wof:name":"Kilsallaghan",
     "wof:parent_id":85685045,
     "wof:placetype":"locality",

--- a/data/101/872/753/101872753.geojson
+++ b/data/101/872/753/101872753.geojson
@@ -158,6 +158,9 @@
         "qs_pg:id":1310793
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"492cca596176e9f00e5693d33cd0bee8",
     "wof:hierarchy":[
         {
@@ -168,7 +171,7 @@
         }
     ],
     "wof:id":101872753,
-    "wof:lastmodified":1566680093,
+    "wof:lastmodified":1582356303,
     "wof:name":"Inishmore",
     "wof:parent_id":85685097,
     "wof:placetype":"locality",

--- a/data/101/872/757/101872757.geojson
+++ b/data/101/872/757/101872757.geojson
@@ -62,6 +62,9 @@
         "wd:id":"Q10992685"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4ece5df445aadf891553d67a72ac5a21",
     "wof:hierarchy":[
         {
@@ -72,7 +75,7 @@
         }
     ],
     "wof:id":101872757,
-    "wof:lastmodified":1566680094,
+    "wof:lastmodified":1582356303,
     "wof:name":"Donaghpatrick",
     "wof:parent_id":85685081,
     "wof:placetype":"locality",

--- a/data/101/872/759/101872759.geojson
+++ b/data/101/872/759/101872759.geojson
@@ -160,6 +160,9 @@
         "qs_pg:id":5
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fe1c6ccb550230a2d01569ac2f638360",
     "wof:hierarchy":[
         {
@@ -170,7 +173,7 @@
         }
     ],
     "wof:id":101872759,
-    "wof:lastmodified":1566680094,
+    "wof:lastmodified":1582356304,
     "wof:name":"Tara",
     "wof:parent_id":85685081,
     "wof:placetype":"locality",

--- a/data/101/872/761/101872761.geojson
+++ b/data/101/872/761/101872761.geojson
@@ -263,6 +263,9 @@
         "wd:id":"Q2399896"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"35a7fb8f5beb708f9c9c9c6cb5219d9f",
     "wof:hierarchy":[
         {
@@ -273,7 +276,7 @@
         }
     ],
     "wof:id":101872761,
-    "wof:lastmodified":1566680094,
+    "wof:lastmodified":1582356303,
     "wof:name":"Skreen",
     "wof:parent_id":85685081,
     "wof:placetype":"locality",

--- a/data/101/872/763/101872763.geojson
+++ b/data/101/872/763/101872763.geojson
@@ -71,6 +71,9 @@
         "wk:page":"Ardcath"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b9671bf8ede534e003b48396d95c51a2",
     "wof:hierarchy":[
         {
@@ -84,7 +87,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566680093,
+    "wof:lastmodified":1582356303,
     "wof:name":"Ardcath",
     "wof:parent_id":85685081,
     "wof:placetype":"locality",

--- a/data/101/872/765/101872765.geojson
+++ b/data/101/872/765/101872765.geojson
@@ -136,6 +136,9 @@
         "wk:page":"Spiddal"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1bdcfaf96e2ddd4975ea1e7440dd824b",
     "wof:hierarchy":[
         {
@@ -149,7 +152,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566680093,
+    "wof:lastmodified":1582356303,
     "wof:name":"Spiddle",
     "wof:parent_id":85685097,
     "wof:placetype":"locality",

--- a/data/101/872/767/101872767.geojson
+++ b/data/101/872/767/101872767.geojson
@@ -118,6 +118,9 @@
         "wk:page":"Drumcliff"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"463cded30c3094598fcfcd2c8bf9313f",
     "wof:hierarchy":[
         {
@@ -128,7 +131,7 @@
         }
     ],
     "wof:id":101872767,
-    "wof:lastmodified":1566680093,
+    "wof:lastmodified":1582356303,
     "wof:name":"Drumcliff",
     "wof:parent_id":85685137,
     "wof:placetype":"locality",

--- a/data/101/872/769/101872769.geojson
+++ b/data/101/872/769/101872769.geojson
@@ -91,6 +91,10 @@
         "wk:page":"Cliffoney"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d8aed21624dbe0a12b0ba3c59d739add",
     "wof:hierarchy":[
         {
@@ -101,7 +105,7 @@
         }
     ],
     "wof:id":101872769,
-    "wof:lastmodified":1566680093,
+    "wof:lastmodified":1582356303,
     "wof:name":"Cliffony",
     "wof:parent_id":85685137,
     "wof:placetype":"locality",

--- a/data/101/872/771/101872771.geojson
+++ b/data/101/872/771/101872771.geojson
@@ -78,6 +78,9 @@
         "wk:page":"Walferdange"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b8d5f81f05ffec271912bf6679f9b6b1",
     "wof:hierarchy":[
         {
@@ -91,7 +94,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566680093,
+    "wof:lastmodified":1582356303,
     "wof:name":"Turlough",
     "wof:parent_id":85685145,
     "wof:placetype":"locality",

--- a/data/101/872/775/101872775.geojson
+++ b/data/101/872/775/101872775.geojson
@@ -88,6 +88,9 @@
         "wd:id":"Q2078132"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"65ed16066e998fecc1d3862955f12f87",
     "wof:hierarchy":[
         {
@@ -101,7 +104,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566680094,
+    "wof:lastmodified":1582356304,
     "wof:name":"Annagary",
     "wof:parent_id":85685151,
     "wof:placetype":"locality",

--- a/data/101/873/683/101873683.geojson
+++ b/data/101/873/683/101873683.geojson
@@ -49,6 +49,9 @@
         "qs_pg:id":4
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5a4924509cd8a7128ab17b7bf8b652f4",
     "wof:hierarchy":[
         {
@@ -59,7 +62,7 @@
         }
     ],
     "wof:id":101873683,
-    "wof:lastmodified":1566680092,
+    "wof:lastmodified":1582356303,
     "wof:name":"Gleneely",
     "wof:parent_id":85685151,
     "wof:placetype":"locality",

--- a/data/101/911/111/101911111.geojson
+++ b/data/101/911/111/101911111.geojson
@@ -64,6 +64,9 @@
         "wd:id":"Q3776366"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b061b7f0cf82f9ecb1bfa6d11b930ccd",
     "wof:hierarchy":[
         {
@@ -74,7 +77,7 @@
         }
     ],
     "wof:id":101911111,
-    "wof:lastmodified":1566680129,
+    "wof:lastmodified":1582356309,
     "wof:name":"Killincarrig",
     "wof:parent_id":85684999,
     "wof:placetype":"locality",

--- a/data/101/911/115/101911115.geojson
+++ b/data/101/911/115/101911115.geojson
@@ -47,6 +47,9 @@
         "qs_pg:id":1025895
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5896b84471ac62716f43ab5a86c6b297",
     "wof:hierarchy":[
         {
@@ -57,7 +60,7 @@
         }
     ],
     "wof:id":101911115,
-    "wof:lastmodified":1566680129,
+    "wof:lastmodified":1582356309,
     "wof:name":"Kilpedder East",
     "wof:parent_id":85684999,
     "wof:placetype":"locality",

--- a/data/101/912/591/101912591.geojson
+++ b/data/101/912/591/101912591.geojson
@@ -77,6 +77,9 @@
         "wd:id":"Q2167772"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8be6713da298784bc76b68013a9a1d04",
     "wof:hierarchy":[
         {
@@ -87,7 +90,7 @@
         }
     ],
     "wof:id":101912591,
-    "wof:lastmodified":1566680123,
+    "wof:lastmodified":1582356308,
     "wof:name":"Rosslare Harbour",
     "wof:parent_id":85684967,
     "wof:placetype":"locality",

--- a/data/101/912/595/101912595.geojson
+++ b/data/101/912/595/101912595.geojson
@@ -94,6 +94,9 @@
         "wk:page":"Strandhill"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2705a84f7ab28c9602c73344ca6922d9",
     "wof:hierarchy":[
         {
@@ -104,7 +107,7 @@
         }
     ],
     "wof:id":101912595,
-    "wof:lastmodified":1566680123,
+    "wof:lastmodified":1582356307,
     "wof:name":"Larass",
     "wof:parent_id":85685137,
     "wof:placetype":"locality",

--- a/data/101/912/793/101912793.geojson
+++ b/data/101/912/793/101912793.geojson
@@ -57,6 +57,9 @@
         "qs_pg:id":996701
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4b0fb4aabe58a5d40022ac817cf49dc1",
     "wof:hierarchy":[
         {
@@ -70,7 +73,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566680123,
+    "wof:lastmodified":1582356308,
     "wof:name":"Cahore",
     "wof:parent_id":85684967,
     "wof:placetype":"locality",

--- a/data/101/912/795/101912795.geojson
+++ b/data/101/912/795/101912795.geojson
@@ -47,6 +47,9 @@
         "qs_pg:id":972507
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1632ea214ce46672ee02c533163d6c18",
     "wof:hierarchy":[
         {
@@ -57,7 +60,7 @@
         }
     ],
     "wof:id":101912795,
-    "wof:lastmodified":1566680123,
+    "wof:lastmodified":1582356308,
     "wof:name":"Rockmarshall",
     "wof:parent_id":85685087,
     "wof:placetype":"locality",

--- a/data/101/912/797/101912797.geojson
+++ b/data/101/912/797/101912797.geojson
@@ -107,6 +107,9 @@
         "qs_pg:id":135930
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"05b75ba1802f7ea50b4cdde5140e85de",
     "wof:hierarchy":[
         {
@@ -117,7 +120,7 @@
         }
     ],
     "wof:id":101912797,
-    "wof:lastmodified":1566680122,
+    "wof:lastmodified":1582356307,
     "wof:name":"Ballyleague",
     "wof:parent_id":85685091,
     "wof:placetype":"locality",

--- a/data/101/912/843/101912843.geojson
+++ b/data/101/912/843/101912843.geojson
@@ -94,6 +94,9 @@
         "wk:page":"Inagh"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"68e43855134a0e837ed5c05bcc344958",
     "wof:hierarchy":[
         {
@@ -107,7 +110,7 @@
     "wof:lang":[
         "dut"
     ],
-    "wof:lastmodified":1566680123,
+    "wof:lastmodified":1582356307,
     "wof:name":"Dysart",
     "wof:parent_id":85685037,
     "wof:placetype":"locality",

--- a/data/856/332/41/85633241.geojson
+++ b/data/856/332/41/85633241.geojson
@@ -1372,6 +1372,11 @@
     },
     "wof:country":"IE",
     "wof:country_alpha3":"IRL",
+    "wof:geom_alt":[
+        "naturalearth",
+        "naturalearth-display-terrestrial-zoom6",
+        "quattroshapes"
+    ],
     "wof:geomhash":"7f01971fab6c32123222b4066078418d",
     "wof:hierarchy":[
         {
@@ -1388,7 +1393,7 @@
         "eng",
         "gle"
     ],
-    "wof:lastmodified":1566679607,
+    "wof:lastmodified":1582356239,
     "wof:name":"Ireland",
     "wof:parent_id":102191581,
     "wof:placetype":"country",

--- a/data/856/849/45/85684945.geojson
+++ b/data/856/849/45/85684945.geojson
@@ -59,6 +59,9 @@
     "wof:breaches":[],
     "wof:concordances":{},
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"61e1d9d02b212218caf52b475d4bfb6f",
     "wof:hierarchy":[
         {
@@ -76,7 +79,7 @@
         "eng",
         "gle"
     ],
-    "wof:lastmodified":1576795625,
+    "wof:lastmodified":1582356250,
     "wof:name":"Cork City",
     "wof:parent_id":85633241,
     "wof:placetype":"region",

--- a/data/856/849/67/85684967.geojson
+++ b/data/856/849/67/85684967.geojson
@@ -336,6 +336,9 @@
         "wd:id":"Q184599"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"37e1f5a285b62328224bc561fb45635b",
     "wof:hierarchy":[
         {
@@ -353,7 +356,7 @@
         "eng",
         "gle"
     ],
-    "wof:lastmodified":1576795651,
+    "wof:lastmodified":1582356247,
     "wof:name":"Wexford",
     "wof:parent_id":85633241,
     "wof:placetype":"region",

--- a/data/856/849/75/85684975.geojson
+++ b/data/856/849/75/85684975.geojson
@@ -349,6 +349,9 @@
         "wd:id":"Q181882"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"11e9e5cb01bd876a0a200f5ca2434505",
     "wof:hierarchy":[
         {
@@ -366,7 +369,7 @@
         "eng",
         "gle"
     ],
-    "wof:lastmodified":1576795655,
+    "wof:lastmodified":1582356251,
     "wof:name":"Carlow",
     "wof:parent_id":85633241,
     "wof:placetype":"region",

--- a/data/856/849/79/85684979.geojson
+++ b/data/856/849/79/85684979.geojson
@@ -374,6 +374,9 @@
         "wd:id":"Q180231"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"86fc3fddacae439723e8756b663e968e",
     "wof:hierarchy":[
         {
@@ -391,7 +394,7 @@
         "eng",
         "gle"
     ],
-    "wof:lastmodified":1576795656,
+    "wof:lastmodified":1582356291,
     "wof:name":"Kilkenny",
     "wof:parent_id":85633241,
     "wof:placetype":"region",

--- a/data/856/849/99/85684999.geojson
+++ b/data/856/849/99/85684999.geojson
@@ -342,6 +342,9 @@
         "wd:id":"Q182591"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2d7eab81be0a0bd094bf56601d2ce8dc",
     "wof:hierarchy":[
         {
@@ -359,7 +362,7 @@
         "eng",
         "gle"
     ],
-    "wof:lastmodified":1576795678,
+    "wof:lastmodified":1582356268,
     "wof:name":"Wicklow",
     "wof:parent_id":85633241,
     "wof:placetype":"region",

--- a/data/856/850/01/85685001.geojson
+++ b/data/856/850/01/85685001.geojson
@@ -231,6 +231,9 @@
         "wd:id":"Q538417"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3435737f65d04629a335f5c4c45d9a2b",
     "wof:hierarchy":[
         {
@@ -248,7 +251,7 @@
         "eng",
         "gle"
     ],
-    "wof:lastmodified":1576795680,
+    "wof:lastmodified":1582356171,
     "wof:name":"Dunlaoghaire-Rathdown",
     "wof:parent_id":85633241,
     "wof:placetype":"region",

--- a/data/856/850/05/85685005.geojson
+++ b/data/856/850/05/85685005.geojson
@@ -342,6 +342,9 @@
         "wd:id":"Q55299"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"139464a9fa8934b015928a6773d6a12b",
     "wof:hierarchy":[
         {
@@ -359,7 +362,7 @@
         "eng",
         "gle"
     ],
-    "wof:lastmodified":1576795681,
+    "wof:lastmodified":1582356157,
     "wof:name":"Laois",
     "wof:parent_id":85633241,
     "wof:placetype":"region",

--- a/data/856/850/09/85685009.geojson
+++ b/data/856/850/09/85685009.geojson
@@ -286,6 +286,9 @@
         "wd:id":"Q822865"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"008fd49ab508ffa4532c05f0e841a9fb",
     "wof:hierarchy":[
         {
@@ -303,7 +306,7 @@
         "eng",
         "gle"
     ],
-    "wof:lastmodified":1576795682,
+    "wof:lastmodified":1582356167,
     "wof:name":"South Dublin",
     "wof:parent_id":85633241,
     "wof:placetype":"region",

--- a/data/856/850/15/85685015.geojson
+++ b/data/856/850/15/85685015.geojson
@@ -129,6 +129,9 @@
         101751737
     ],
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"960ab3105313d2a86d64d94d84667d80",
     "wof:hierarchy":[
         {
@@ -146,7 +149,7 @@
         "eng",
         "gle"
     ],
-    "wof:lastmodified":1576795683,
+    "wof:lastmodified":1582356193,
     "wof:name":"Dublin City",
     "wof:parent_id":85633241,
     "wof:placetype":"region",

--- a/data/856/850/25/85685025.geojson
+++ b/data/856/850/25/85685025.geojson
@@ -346,6 +346,9 @@
         "wd:id":"Q173332"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6fd0ba61cbf61925db8748ec3020f9d8",
     "wof:hierarchy":[
         {
@@ -363,7 +366,7 @@
         "eng",
         "gle"
     ],
-    "wof:lastmodified":1576795684,
+    "wof:lastmodified":1582356193,
     "wof:name":"Kildare",
     "wof:parent_id":85633241,
     "wof:placetype":"region",

--- a/data/856/850/37/85685037.geojson
+++ b/data/856/850/37/85685037.geojson
@@ -340,6 +340,9 @@
         "wd:id":"Q181862"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d17f4d7b0a757096d8112a0e52b94d1a",
     "wof:hierarchy":[
         {
@@ -357,7 +360,7 @@
         "eng",
         "gle"
     ],
-    "wof:lastmodified":1576795685,
+    "wof:lastmodified":1582356169,
     "wof:name":"Clare",
     "wof:parent_id":85633241,
     "wof:placetype":"region",

--- a/data/856/850/41/85685041.geojson
+++ b/data/856/850/41/85685041.geojson
@@ -338,6 +338,9 @@
         "wd:id":"Q184445"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"957a615a5538b11b53115cced0a42a58",
     "wof:hierarchy":[
         {
@@ -355,7 +358,7 @@
         "eng",
         "gle"
     ],
-    "wof:lastmodified":1576795689,
+    "wof:lastmodified":1582356191,
     "wof:name":"Offaly",
     "wof:parent_id":85633241,
     "wof:placetype":"region",

--- a/data/856/850/45/85685045.geojson
+++ b/data/856/850/45/85685045.geojson
@@ -301,6 +301,9 @@
         "wd:id":"Q520000"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7cee5b02e217666a617e6ebe61ba0109",
     "wof:hierarchy":[
         {
@@ -318,7 +321,7 @@
         "eng",
         "gle"
     ],
-    "wof:lastmodified":1576795690,
+    "wof:lastmodified":1582356160,
     "wof:name":"Fingal",
     "wof:parent_id":85633241,
     "wof:placetype":"region",

--- a/data/856/850/55/85685055.geojson
+++ b/data/856/850/55/85685055.geojson
@@ -59,6 +59,9 @@
     "wof:breaches":[],
     "wof:concordances":{},
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4488de6a5e2eaf4afe0a0ba0b7a02707",
     "wof:hierarchy":[
         {
@@ -76,7 +79,7 @@
         "eng",
         "gle"
     ],
-    "wof:lastmodified":1576795693,
+    "wof:lastmodified":1582356172,
     "wof:name":"Galway City",
     "wof:parent_id":85633241,
     "wof:placetype":"region",

--- a/data/856/850/75/85685075.geojson
+++ b/data/856/850/75/85685075.geojson
@@ -329,6 +329,9 @@
         "wd:id":"Q182633"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c93d03227b34742d4d763385330bb8a5",
     "wof:hierarchy":[
         {
@@ -346,7 +349,7 @@
         "eng",
         "gle"
     ],
-    "wof:lastmodified":1576795694,
+    "wof:lastmodified":1582356164,
     "wof:name":"Westmeath",
     "wof:parent_id":85633241,
     "wof:placetype":"region",

--- a/data/856/850/81/85685081.geojson
+++ b/data/856/850/81/85685081.geojson
@@ -352,6 +352,9 @@
         "wd:id":"Q183544"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"794626942812cfb53603c10242be300d",
     "wof:hierarchy":[
         {
@@ -369,7 +372,7 @@
         "eng",
         "gle"
     ],
-    "wof:lastmodified":1576795696,
+    "wof:lastmodified":1582356165,
     "wof:name":"Meath",
     "wof:parent_id":85633241,
     "wof:placetype":"region",

--- a/data/856/850/87/85685087.geojson
+++ b/data/856/850/87/85685087.geojson
@@ -358,6 +358,9 @@
         "wd:id":"Q183539"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"afead9e22bd95cb56a7624629672a6eb",
     "wof:hierarchy":[
         {
@@ -375,7 +378,7 @@
         "eng",
         "gle"
     ],
-    "wof:lastmodified":1576795698,
+    "wof:lastmodified":1582356163,
     "wof:name":"Louth",
     "wof:parent_id":85633241,
     "wof:placetype":"region",

--- a/data/856/850/91/85685091.geojson
+++ b/data/856/850/91/85685091.geojson
@@ -337,6 +337,9 @@
         "wd:id":"Q186220"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"47097fa86a4773c4f6120c034a341bb9",
     "wof:hierarchy":[
         {
@@ -354,7 +357,7 @@
         "eng",
         "gle"
     ],
-    "wof:lastmodified":1576795699,
+    "wof:lastmodified":1582356168,
     "wof:name":"Longford",
     "wof:parent_id":85633241,
     "wof:placetype":"region",

--- a/data/856/851/13/85685113.geojson
+++ b/data/856/851/13/85685113.geojson
@@ -342,6 +342,9 @@
         "wd:id":"Q179437"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4faf53ce371c7cbd0f3775d73fb6b30b",
     "wof:hierarchy":[
         {
@@ -359,7 +362,7 @@
         "eng",
         "gle"
     ],
-    "wof:lastmodified":1576795718,
+    "wof:lastmodified":1582356234,
     "wof:name":"Roscommon",
     "wof:parent_id":85633241,
     "wof:placetype":"region",

--- a/data/856/851/17/85685117.geojson
+++ b/data/856/851/17/85685117.geojson
@@ -335,6 +335,9 @@
         "wd:id":"Q184760"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a62520e97085a278b16a6a58ebf5bb1c",
     "wof:hierarchy":[
         {
@@ -352,7 +355,7 @@
         "eng",
         "gle"
     ],
-    "wof:lastmodified":1576795720,
+    "wof:lastmodified":1582356229,
     "wof:name":"Monaghan",
     "wof:parent_id":85633241,
     "wof:placetype":"region",

--- a/data/856/851/25/85685125.geojson
+++ b/data/856/851/25/85685125.geojson
@@ -343,6 +343,9 @@
         "wd:id":"Q187402"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"636cb4d55a540e6d0fa6ee1b34daca19",
     "wof:hierarchy":[
         {
@@ -360,7 +363,7 @@
         "eng",
         "gle"
     ],
-    "wof:lastmodified":1576795721,
+    "wof:lastmodified":1582356236,
     "wof:name":"Cavan",
     "wof:parent_id":85633241,
     "wof:placetype":"region",

--- a/data/856/851/33/85685133.geojson
+++ b/data/856/851/33/85685133.geojson
@@ -345,6 +345,9 @@
         "wd:id":"Q107397"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"28ad7825dc69513c0c403a9ef7eeace7",
     "wof:hierarchy":[
         {
@@ -362,7 +365,7 @@
         "eng",
         "gle"
     ],
-    "wof:lastmodified":1576795723,
+    "wof:lastmodified":1582356216,
     "wof:name":"Leitrim",
     "wof:parent_id":85633241,
     "wof:placetype":"region",

--- a/data/856/851/37/85685137.geojson
+++ b/data/856/851/37/85685137.geojson
@@ -344,6 +344,9 @@
         "wd:id":"Q179325"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9a8b299846dff57dc13ee91e4aec1cb8",
     "wof:hierarchy":[
         {
@@ -361,7 +364,7 @@
         "eng",
         "gle"
     ],
-    "wof:lastmodified":1576795725,
+    "wof:lastmodified":1582356231,
     "wof:name":"Sligo",
     "wof:parent_id":85633241,
     "wof:placetype":"region",

--- a/data/857/942/03/85794203.geojson
+++ b/data/857/942/03/85794203.geojson
@@ -120,6 +120,9 @@
         "wk:page":"Cabinteely"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"05030553fef4122afd79c1349a71cc7f",
     "wof:hierarchy":[
         {
@@ -134,7 +137,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566679512,
+    "wof:lastmodified":1582356147,
     "wof:name":"Cabinteely",
     "wof:parent_id":101751737,
     "wof:placetype":"neighbourhood",

--- a/data/857/943/79/85794379.geojson
+++ b/data/857/943/79/85794379.geojson
@@ -125,6 +125,9 @@
         "wk:page":"Sandyford"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fc3688d5f8ddfbcda8df6a53690c9120",
     "wof:hierarchy":[
         {
@@ -139,7 +142,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566679513,
+    "wof:lastmodified":1582356147,
     "wof:name":"Sandyford",
     "wof:parent_id":101751737,
     "wof:placetype":"neighbourhood",

--- a/data/858/662/33/85866233.geojson
+++ b/data/858/662/33/85866233.geojson
@@ -102,6 +102,9 @@
         "wk:page":"Sandycove"
     },
     "wof:country":"IE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"30c24be7aecdecb76af826a1a62c54b9",
     "wof:hierarchy":[
         {
@@ -116,7 +119,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566679679,
+    "wof:lastmodified":1582356292,
     "wof:name":"Sandycove",
     "wof:parent_id":101751737,
     "wof:placetype":"neighbourhood",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.