### PR TITLE
Update Multyfarnham records

### DIFF
--- a/data/174/614/014/7/1746140147.geojson
+++ b/data/174/614/014/7/1746140147.geojson
@@ -1,26 +1,24 @@
 {
-  "id": 1125325771,
+  "id": 1746140147,
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
-    "edtf:deprecated":"2021-08-13",
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"-7.38333,53.61667,-7.38333,53.61667",
-    "geom:latitude":53.61667,
-    "geom:longitude":-7.38333,
+    "geom:bbox":"-7.38882,53.625356,-7.38882,53.625356",
+    "geom:latitude":53.625356,
+    "geom:longitude":-7.38882,
     "gn:country":"IE",
     "gn:fcode":"PPL",
     "gn:population":0,
     "iso:country":"IE",
-    "lbl:bbox":"-7.48333,53.51667,-7.28333,53.71667",
-    "lbl:latitude":53.61667,
-    "lbl:longitude":-7.38333,
+    "lbl:latitude":53.625356,
+    "lbl:longitude":-7.38882,
     "lbl:max_zoom":17.0,
     "lbl:min_zoom":12.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":0,
+    "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
     "name:ceb_x_preferred":[
@@ -73,7 +71,7 @@
     "qs_pg:qs_pg_placetype_gp":"LocalAdmin",
     "qs_pg:woe_adm0":23424803,
     "qs_pg:woe_id":20074327,
-    "src:geom":"qs_pg",
+    "src:geom":"whosonfirst",
     "src:lbl_centroid":"qs_pg",
     "src:population":"geonames",
     "woe:adm0_id":23424803,
@@ -92,35 +90,34 @@
         "qs_pg:id":500558
     },
     "wof:country":"IE",
-    "wof:created":1497044804,
-    "wof:geomhash":"91b85a11f13e920adc798ede32e6b0e7",
+    "wof:geomhash":"1dda90b5ec926f91d94ceecbc10b1cb6",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
             "country_id":85633241,
-            "localadmin_id":1125325771,
+            "locality_id":1746140147,
             "region_id":85685075
         }
     ],
-    "wof:id":1125325771,
-    "wof:lastmodified":1628880983,
+    "wof:id":1746140147,
+    "wof:lastmodified":1628881055,
     "wof:name":"Multyfarnham",
     "wof:parent_id":85685075,
-    "wof:placetype":"localadmin",
+    "wof:placetype":"locality",
     "wof:population":376,
     "wof:population_rank":2,
     "wof:repo":"whosonfirst-data-admin-ie",
-    "wof:superseded_by":[
-        1746140147
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1125325771
     ],
-    "wof:supersedes":[],
     "wof:tags":[]
 },
   "bbox": [
-    -7.38333,
-    53.61667,
-    -7.38333,
-    53.61667
+    -7.38882,
+    53.625356,
+    -7.38882,
+    53.625356
 ],
-  "geometry": {"coordinates":[-7.38333,53.61667],"type":"Point"}
+  "geometry": {"coordinates":[-7.38882,53.625356],"type":"Point"}
 }


### PR DESCRIPTION
This PR:

- Deprecates a localadmin record for Multyfarnham, Ireland, superseding it into a new locality for Multyfarnham.
- Creates a new locality record for Multyfarnham, with an updated geometry.

No PIP work required, I've manually adjusted the hierarchy in the new record. This can be merged once approved.